### PR TITLE
Restored default routes to EC2 metadata service

### DIFF
--- a/two-tier-sample/pan-sample-cft.json
+++ b/two-tier-sample/pan-sample-cft.json
@@ -482,6 +482,7 @@
             "echo \"export new_routers='",{"Fn::GetAtt" : [ "FWPrivate13NetworkInterface", "PrimaryPrivateIpAddress" ]},"'\" >> /etc/dhcp/dhclient-enter-hooks.d/aws-default-route\n",
             "ifdown eth0\n",
             "ifup eth0\n",
+            "route add -net 169.254.0.0 netmask 255.255.0.0 dev eth0\n",
             "while true\n",
             " do\n",
             "  resp=$(curl -s -S -g --insecure \"https://",{"Ref": "ManagementElasticIP"},"/api/?type=op&cmd=<show><chassis-ready></chassis-ready></show>&key=LUFRPT10VGJKTEV6a0R4L1JXd0ZmbmNvdUEwa25wMlU9d0N5d292d2FXNXBBeEFBUW5pV2xoZz09\")\n",
@@ -548,7 +549,7 @@
             "echo \"export new_routers='",{"Fn::GetAtt" : [ "FWPrivate12NetworkInterface", "PrimaryPrivateIpAddress" ]},"'\" >> /etc/dhcp/dhclient-enter-hooks.d/aws-default-route\n",
             "ifdown eth0\n",
             "ifup eth0\n",
-
+            "route add -net 169.254.0.0 netmask 255.255.0.0 dev eth0\n",
             "while true\n",
             "  do\n",
             "   resp=$(curl -s -S -g --insecure \"https://",{"Ref": "ManagementElasticIP"},"/api/?type=op&cmd=<show><chassis-ready></chassis-ready></show>&key=LUFRPT10VGJKTEV6a0R4L1JXd0ZmbmNvdUEwa25wMlU9d0N5d292d2FXNXBBeEFBUW5pV2xoZz09\")\n",


### PR DESCRIPTION
Adding the firewall VM as a router in this way destroys some local routes which need to exist for IAM Instance Profiles to work correctly. This change restores static routes to the relevant addresses.

The current setup also grants any instance within the VPC access to IAM credentials associated with the firewall instance, since the firewall handles these requests and returns its own metadata in response.